### PR TITLE
Update README.creole

### DIFF
--- a/README.creole
+++ b/README.creole
@@ -75,9 +75,9 @@ the port you selected and use the username and password from the
     6901                                     ; port you started the bouncer on
     "nick-at-the-irc-network"                ; the Nick to use (only used locally)
     "user-to-connect-to-the-irc-network"     ; the username to connect to bouncer
-    "password-to-connect-to-the-irc-network" ; the password to connect to bouncer
     "Full Name"                              ; full name (not used I think)
-    ("#channel" "#otherchannel"))            ; start channels (not used I think)
+    '("#channel" "#otherchannel")            ; start channels (not used I think)
+    "password-to-connect-to-the-irc-network"); the password to connect to bouncer
 }}}
 
 This will connect to the bouncer and everything //should// work.
@@ -119,9 +119,9 @@ You can connect to these with:
     6901
     "bouncer-nick"
     "bouncer-username@irc-one.upstream.servername"
-    "password" 
     "Full Name"
-    ("#channel" "#otherchannel"))
+    '("#channel" "#otherchannel")
+    "password")
 }}}
 
 for the second one:
@@ -132,9 +132,9 @@ for the second one:
     6901
     "bouncer-nick"
     "bouncer-username@irc-two.upstream.servername"
-    "password" 
     "Full Name"
-    ("#channel" "#otherchannel"))
+    '("#channel" "#otherchannel")
+    "password")
 }}}
 
 


### PR DESCRIPTION
The documentation has signature for rcirc-connect mixed up. password should be the last argument and startup-channels should be quoted

``` lisp
(defun rcirc-connect (server &optional port nick user-name
                             full-name startup-channels password encryption)
```

Btw, thanks for helping make Emacs even more awesome!
