### PR TITLE
Various improvements and bug fixes

### DIFF
--- a/shoes-off.el
+++ b/shoes-off.el
@@ -517,8 +517,11 @@ is not sent to the IRC session.")
 (defun shoes-off-stop ()
   "Stop the bouncer daemon."
   (interactive)
-  (delete-process shoes-off/server-process))
-
+  (if (not shoes-off/server-process)
+      (message "Shoes-off: not running.")
+    (delete-process shoes-off/server-process)
+    (setq shoes-off/server-process nil)
+    (message "Shoes-off: stopped.")))
 
 ;; Bouncer setup
 

--- a/shoes-off.el
+++ b/shoes-off.el
@@ -641,10 +641,9 @@ Initiates the upstream IRC connections for the user."
                 &key
                 nick port user-name
                 password full-name
-                channels) server-config
+                channels encryption) server-config
            ;; Connect the client socket
-           (let* (encryption ; hacked for now
-                  (connection
+           (let* ((connection
                    (if (functionp shoes-off/rcirc-connect-plugin)
                        (funcall shoes-off/rcirc-connect-plugin
                                 server port nick user-name

--- a/shoes-off.el
+++ b/shoes-off.el
@@ -332,9 +332,8 @@ example."
 (defun shoes-off/get-session (process)
   "Get the associated session from the client process."
   (let* ((auth (shoes-off/get-auth-details process))
-         (user (plist-get auth :username))
-         (server (plist-get auth :server-alist)))
-    (gethash (format "%s@%s" user (caar server)) shoes-off/sessions)))
+         (user (plist-get auth :username)))
+    (gethash user shoes-off/sessions)))
 
 
 (defconst shoes-off/cache-response-welcome-commands


### PR DESCRIPTION
In chronological order:
- Support the :encryption keyword. It was allowed in the defcustom but wasn't allowed by shoes-off-start-new-session. It is now both allowed and used.
- Allow the user the customize the port used by the bouncer directly in shoes-off-config
- Do the same thing but for the host. This way we can now restrain the bouncer to listen on localhost only.
- Minor improvement of shoes-off-stop
- Fixed a regression in shoes-off/get-session
