### PR TITLE
Make shoes-off require shoes-off-log

### DIFF
--- a/shoes-off.el
+++ b/shoes-off.el
@@ -28,6 +28,7 @@
 (require 'kv)
 (require 'rcirc)
 (require 'assoc)
+(require 'shoes-off-log)
 
 (defgroup shoes-off nil
   "An irc bouncer."


### PR DESCRIPTION
This lets requiring or loading shoes-off work in the absence
of autoloads.
